### PR TITLE
修改README示例中的Seq_to_vec函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,9 @@ def Seq_to_vec(Sequence):
             seq_emd = embedding[seq_num][:seq_len - 1]
             features.append(seq_emd)
     features_normalize = np.zeros([len(features), len(features[0][0])], dtype=float)
-    for i in range(len(features)):
-        for k in range(len(features[0][0])):
-            for j in range(len(features[i])):
-                features_normalize[i][k] += features[i][j][k]
-            features_normalize[i][k] /= len(features[i])
+    features_array = np.array(features)
+    for n in range(len(features)):
+        features_normalize[n] = features_array[n].mean(axis=0, dtype=np.float64)
     return features_normalize
 
 


### PR DESCRIPTION
最后的向量转换由for循环转换为np.mean方法，以提高批量计算时的速度。